### PR TITLE
To be compatible with npm test in docker.

### DIFF
--- a/app/waf/test/acceptance/test-helper.ts
+++ b/app/waf/test/acceptance/test-helper.ts
@@ -8,7 +8,10 @@ import {testdb} from '../fixtures/datasources/testdb.datasource';
 
 export async function setupApplication(): Promise<AppWithClient> {
   const app = new WafApplication({
-    rest: givenHttpServerConfig(),
+    rest: givenHttpServerConfig({
+      host: '0.0.0.0',
+      port: 3000,
+    }),
   });
   app.dataSource(testdb);
 


### PR DESCRIPTION
fix the 'npm test' failure in docker.

  Error: connect EADDRNOTAVAIL ::1:37663 - Local (:::0)
      at internalConnect (net.js:857:16)
      at defaultTriggerAsyncIdScope (internal/async_hooks.js:294:19)
      at defaultTriggerAsyncIdScope (net.js:947:9)
      at process.internalTickCallback (internal/process/next_tick.js:70:11)