### PR TITLE
take test/*.ts out of coverage calculation

### DIFF
--- a/app/waf/package.json
+++ b/app/waf/package.json
@@ -45,6 +45,11 @@
     "dist/index*",
     "src"
   ],
+  "nyc": {
+    "exclude": [
+      "dist/test/**"
+    ]
+  },
   "dependencies": {
     "@loopback/boot": "^1.0.6",
     "@loopback/context": "^1.2.0",


### PR DESCRIPTION
The test/**.ts should be taken out of coverage calculation. 
Or the total coverage would be inaccurate.