### PR TITLE
Cap nyc version until node-coveralls can support nyc 14

### DIFF
--- a/app/waf/package.json
+++ b/app/waf/package.json
@@ -72,6 +72,7 @@
     "@loopback/testlab": "^1.0.1",
     "@types/node": "^10.11.2",
     "coveralls": "^3.0.0",
+    "nyc": "^13.0.0",
     "typescript": "^3.3.1"
   }
 }


### PR DESCRIPTION
Open a bug in node-coveralls  https://github.com/nickmerwin/node-coveralls/issues/219