### PR TITLE
Fix the issue of travis failure caused by typescript -> 3.5.1.

### DIFF
--- a/app/waf/package.json
+++ b/app/waf/package.json
@@ -75,6 +75,6 @@
     "@types/node": "^10.11.2",
     "coveralls": "^3.0.0",
     "nyc": "^13.0.0",
-    "typescript": "^3.3.1"
+    "typescript": "<=3.4.5"
   }
 }


### PR DESCRIPTION
We may need to check the 3.5.1's new feature and re-enable it.