### PR TITLE
Refresh and use user token's endpoints for openstack api call.

### DIFF
--- a/app/waf/src/datasources/openstack.datasource.json
+++ b/app/waf/src/datasources/openstack.datasource.json
@@ -41,6 +41,19 @@
       }
     },
     {
+      "description": "identity v2 refresh user's token.",
+      "template": {
+        "method": "POST",
+        "url": "{url}",
+        "responsePath": "$"
+      },
+      "functions": {
+        "v2RefreshToken": [
+          "url"
+        ]
+      }
+    },
+    {
       "description": "identity v3 get auth token with user/password",
       "template": {
         "method": "POST",
@@ -73,6 +86,22 @@
           "url",
           "adminToken",
           "userToken"
+        ]
+      }
+    },
+    {
+      "description": "identity v3 refresh user's token.",
+      "template": {
+        "method": "POST",
+        "url": "{url}",
+        "responsePath": "$",
+        "responseHeaders": true,
+        "body": "{body}"
+      },
+      "functions": {
+        "v3RefreshToken": [
+          "url",
+          "body"
         ]
       }
     },

--- a/app/waf/src/keys.ts
+++ b/app/waf/src/keys.ts
@@ -56,7 +56,7 @@ export namespace WafBindingKeys {
     export const KeyTenantId = BindingKey.create<string>(
       'context.request.tenantid',
     );
-    export const KeyUserToken = BindingKey.create<string>(
+    export const KeyUserToken = BindingKey.create<AuthedToken>(
       'context.request.usertoken',
     );
   }

--- a/app/waf/src/services/identity.service.ts
+++ b/app/waf/src/services/identity.service.ts
@@ -24,12 +24,14 @@ import {WafBindingKeys} from '../keys';
 export interface IdentityService {
   v2AuthToken(url: string, body: object): Promise<object>;
   v2ValidateToken(url: string, adminToken: string): Promise<object>;
+  v2RefreshToken(url: string, body: object): Promise<object>;
   v3AuthToken(url: string, body: object): Promise<object>;
   v3ValidateToken(
     url: string,
     adminToken: string,
     userToken: string,
   ): Promise<object>;
+  v3RefreshToken(url: string, body: object): Promise<object>;
 }
 
 export class IdentityServiceProvider implements Provider<IdentityService> {
@@ -60,6 +62,10 @@ export abstract class AuthWithOSIdentity {
     userToken: string,
     tenantId?: string,
   ): Promise<AuthedToken>;
+  abstract refreshUserToken(
+    userToken: string,
+    tenantId: string,
+  ): Promise<AuthedToken>;
 
   // async bindIdentityService() {
   //   // TODO: use bind/inject to use IdentityService:
@@ -89,6 +95,31 @@ export abstract class AuthWithOSIdentity {
         this.logger.debug('solveAdminToken failed: ' + error.message);
         throw error;
       }
+    }
+  }
+
+  async solveUserToken(
+    oldToken: AuthedToken,
+    expiredAfterSecs: number = 600,
+  ): Promise<AuthedToken> {
+    try {
+      if (oldToken.aboutExpired(expiredAfterSecs)) {
+        this.logger.debug(
+          `The token is about to expire in ${expiredAfterSecs} seconds, refresh it for later operations.`,
+        );
+
+        return await this.application
+          .get(WafBindingKeys.KeyAuthWithOSIdentity)
+          .then(authHelper => {
+            return authHelper.refreshUserToken(
+              oldToken.token,
+              oldToken.tenantId,
+            );
+          });
+      } else return oldToken;
+    } catch (error) {
+      this.logger.debug('solveUserToken failed: ' + error.message);
+      throw error;
     }
   }
 }
@@ -131,6 +162,30 @@ class AuthWithIdentityV2 extends AuthWithOSIdentity {
     try {
       return await this.identityService
         .v2ValidateToken(url, adminToken.token)
+        .then(response => {
+          return AuthedToken.buildWith(response);
+        });
+    } catch (error) {
+      throw new Error('Failed to validate user token: ' + error.message);
+    }
+  }
+
+  async refreshUserToken(
+    userToken: string,
+    tenantId: string,
+  ): Promise<AuthedToken> {
+    let url = this.authConfig.osAuthUrl + '/tokens';
+    let body = {
+      auth: {
+        token: {
+          id: userToken,
+        },
+        tenantId: tenantId,
+      },
+    };
+    try {
+      return await this.identityService
+        .v2RefreshToken(url, body)
         .then(response => {
           return AuthedToken.buildWith(response);
         });
@@ -196,6 +251,37 @@ class AuthWithIdentityV3 extends AuthWithOSIdentity {
       throw new Error('Failed to validate user token: ' + error.message);
     }
   }
+
+  async refreshUserToken(
+    userToken: string,
+    tenantId: string,
+  ): Promise<AuthedToken> {
+    let url = this.authConfig.osAuthUrl + '/auth/tokens';
+    let body = {
+      auth: {
+        identity: {
+          methods: ['token'],
+          token: {
+            id: userToken,
+          },
+        },
+        scope: {
+          project: {
+            id: tenantId,
+          },
+        },
+      },
+    };
+    try {
+      return await this.identityService
+        .v3RefreshToken(url, body)
+        .then(response => {
+          return AuthedToken.buildWith(response);
+        });
+    } catch (error) {
+      throw new Error('Failed to validate user token: ' + error.message);
+    }
+  }
 }
 
 export class AuthWithIdentityUnknown extends AuthWithOSIdentity {
@@ -203,6 +289,9 @@ export class AuthWithIdentityUnknown extends AuthWithOSIdentity {
     throw new Error('Not Implemented, unknown AuthWithOSIdentity.');
   }
   validateUserToken(userToken: string, tenantId: string): Promise<AuthedToken> {
+    throw new Error('Not Implemented, unknown AuthWithOSIdentity.');
+  }
+  refreshUserToken(userToken: string, tenantId: string): Promise<AuthedToken> {
     throw new Error('Not Implemented, unknown AuthWithOSIdentity.');
   }
 }
@@ -333,6 +422,10 @@ export class AuthedToken {
     }
   }
 
+  public aboutExpired(sec: number): boolean {
+    return this.expiredAt.getTime() - Date.now() < sec * 1000;
+  }
+
   private buildV2_0(response: object): AuthedToken {
     let respJson = JSON.parse(JSON.stringify(response));
 
@@ -387,8 +480,7 @@ export class AuthedToken {
   private digExpired() {
     // Make the duration time a little shorter then that of actually
     // to avoid token expiring error caused by time leak.
-    let duration =
-      ((this.expiredAt.getTime() - this.issuedAt.getTime()) * 4) / 5;
+    let duration = this.expiredAt.getTime() - this.issuedAt.getTime();
     this.expiredAt.setTime(Date.now() + duration);
     return this;
   }
@@ -464,11 +556,7 @@ export class AuthedToken {
     return this.epNetwork() + '/v2.0/subnets';
   }
 
-  // TODO: Use user token's catalog instead of that of admin's.
-  public epServers(tenantId: string) {
-    let url = this.epCompute();
-    if (url.endsWith('v2.0'))
-      return url.slice(0, url.lastIndexOf('/')) + '/' + tenantId + '/servers';
-    else return url.replace(process.env.OS_TENANT_ID!, tenantId) + '/servers';
+  public epServers() {
+    return this.epCompute() + '/servers';
   }
 }

--- a/app/waf/test/acceptance/openstack.controller.acceptance.ts
+++ b/app/waf/test/acceptance/openstack.controller.acceptance.ts
@@ -341,6 +341,156 @@ describe('openstack.identity.test', () => {
     expect(response.body).hasOwnProperty('message');
   });
 
+  it('refresh user token v2: 200', async () => {
+    ShouldResponseWith({'/v2.0/tokens': StubResponses.v2AuthToken200});
+    let response = await client
+      .get('/openstack/refreshUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v2.0',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body.userId).eql(ExpectedData.userId);
+  });
+
+  it('refresh user token v2: 401', async () => {
+    ShouldResponseWith({'/v2.0/tokens': StubResponses.response401});
+    let response = await client
+      .get('/openstack/refreshUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v2.0',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body).hasOwnProperty('message');
+  });
+
+  it('refresh user token v3: 200', async () => {
+    ShouldResponseWith({'/v3/auth/tokens': StubResponses.v3AuthToken200});
+    let response = await client
+      .get('/openstack/refreshUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v3',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body.token).eql(ExpectedData.userToken);
+  });
+
+  it('refresh user token v3: 401', async () => {
+    ShouldResponseWith({'/v3/auth/tokens': StubResponses.response401});
+    let response = await client
+      .get('/openstack/refreshUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v3',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body).hasOwnProperty('message');
+  });
+
+  it('resolve user token v3: 200', async () => {
+    ShouldResponseWith({'/v3/auth/tokens': StubResponses.v3AuthToken200});
+    let response = await client
+      .get('/openstack/resolveUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v3',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body.token).eql(ExpectedData.userToken);
+  });
+
+  it('resolve user token v3: 401', async () => {
+    ShouldResponseWith({'/v3/auth/tokens': StubResponses.response401});
+    let response = await client
+      .get('/openstack/resolveUserToken')
+      .send({
+        env: {
+          OS_AUTH_URL: 'http://localhost:35357/v3',
+          OS_USERNAME: 'wafaas',
+          OS_PASSWORD: '91153c85b8dd4147',
+          OS_TENANT_ID: '32b8bef6100e4cb0a984a7c1f9027802',
+          OS_DOMAIN_NAME: 'Default',
+          OS_REGION_NAME: 'RegionOne',
+          OS_AVAILABLE_ZONE: 'nova',
+        },
+        param: {
+          adminToken: '630daf7125a64d67b309e48603cbe461',
+          userToken: '149bfc5ac96c442db50ced09cf075479',
+          tenantName: '9f91a149-a847-41f9-96e2-2831c65948f4',
+        },
+      })
+      .expect(200);
+
+    expect(response.body).hasOwnProperty('message');
+  });
+
   it('create vm with network id: 200', async () => {
     ShouldResponseWith({
       '/v2/{tenantId}/servers': StubResponses.novaCreateVM200,

--- a/app/waf/test/acceptance/sequence.acceptance.ts
+++ b/app/waf/test/acceptance/sequence.acceptance.ts
@@ -102,6 +102,7 @@ describe('openstack.identity.test', () => {
     let response = await client
       .get('/test-openstack-simulation-ok')
       .set('X-Auth-Token', ExpectedData.userToken)
+      .set('tenant-id', ExpectedData.tenantId)
       .send()
       .expect(200);
 

--- a/app/waf/test/fixtures/controllers/mocks/mock.openstack.controller.ts
+++ b/app/waf/test/fixtures/controllers/mocks/mock.openstack.controller.ts
@@ -36,7 +36,12 @@ export class MockKeyStoneController extends MockBaseController {
     super();
   }
   @post('/v2.0/tokens')
-  async v2AuthToken(@requestBody() reqBody: RequestBody): Promise<object> {
+  async v2PostAuthToken(@requestBody() reqBody: RequestBody): Promise<object> {
+    return ResponseWith['/v2.0/tokens']();
+  }
+
+  @get('/v2.0/tokens')
+  async v2GetAuthToken(@requestBody() reqBody: RequestBody): Promise<object> {
     return ResponseWith['/v2.0/tokens']();
   }
 

--- a/app/waf/test/fixtures/datasources/testrest.datasource.ts
+++ b/app/waf/test/fixtures/datasources/testrest.datasource.ts
@@ -76,7 +76,7 @@ export const StubResponses = {
           tenant: {
             description: 'admin tenant',
             enabled: true,
-            id: 'fde45211da0a44ecbf38cb0b644ab30d',
+            id: ExpectedData.tenantId,
             name: 'admin',
           },
           audit_ids: ['PGH3khYCThGlNngmcfVnTQ'],
@@ -199,13 +199,13 @@ export const StubResponses = {
             name: 'admin',
           },
         ],
-        expires_at: '2020-05-03T02:15:58.000000Z',
+        expires_at: '2019-03-13T10:16:58.000000Z', // expired in 1 min.
         project: {
           domain: {
             id: 'default',
             name: 'Default',
           },
-          id: 'fde45211da0a44ecbf38cb0b644ab30d',
+          id: ExpectedData.tenantId,
           name: 'admin',
         },
         catalog: [


### PR DESCRIPTION
Why do we have this PR:

We are now using admin token to get service endpoints(compute, network, identity..)
The normal way should be using the user token. 2 benefits: 

1. The passed-in user token should not be used directly, since it may be expired in a very short time(eg. < 1s), but the operation takes a longer time. So we need to refresh a new user token and do the following works with it. 
2. We can get service endpoints directly from user token's catalogs, instead of assembling it from admin tokens. 