### PR TITLE
Move trustedDeviceId from adc to adc.management.

### DIFF
--- a/app/waf/src/controllers/wafpolicy.controller.ts
+++ b/app/waf/src/controllers/wafpolicy.controller.ts
@@ -169,7 +169,7 @@ export class WafpolicyController extends BaseController {
       tenantId: await this.tenantId,
     });
 
-    if (adc.trustedDeviceId === undefined) {
+    if (!adc.management.trustedDeviceId) {
       throw new HttpErrors.UnprocessableEntity(`Adc: ${adc.id} is not trusted`);
     }
 
@@ -178,7 +178,7 @@ export class WafpolicyController extends BaseController {
     try {
       await this.asgMgr.wafpolicyUploadByUrl(
         wafpolicy.url,
-        adc.trustedDeviceId,
+        adc.management.trustedDeviceId!,
         wafpolicy.id,
       );
     } catch (error) {
@@ -214,7 +214,7 @@ export class WafpolicyController extends BaseController {
       tenantId: await this.tenantId,
     });
 
-    if (adc.trustedDeviceId === undefined) {
+    if (!adc.management.trustedDeviceId) {
       throw new HttpErrors.UnprocessableEntity(`Adc: ${adc.id} is not trusted`);
     }
 
@@ -223,7 +223,7 @@ export class WafpolicyController extends BaseController {
     let resp = undefined;
     try {
       resp = await this.asgMgr.wafpolicyCheckByName(
-        adc.trustedDeviceId,
+        adc.management.trustedDeviceId!,
         wafpolicy.id,
       );
     } catch (error) {

--- a/app/waf/src/models/adc.model.ts
+++ b/app/waf/src/models/adc.model.ts
@@ -69,6 +69,7 @@ export type ConfigTypes = {
         //vips?: [string]; // cannot be appointed.
       };
     };
+    trustedDeviceId?: string;
   };
   status: string; // cannot be appointed.
   lastErr: string; // cannot be appointed.
@@ -140,16 +141,6 @@ export class Adc extends CommonEntity {
     },
   })
   management: ConfigTypes['management'];
-
-  @property({
-    type: 'string',
-    required: false,
-    schema: {
-      response: true,
-      example: '2c52df5f-a393-40d8-9013-475eb54f7bef',
-    },
-  })
-  trustedDeviceId?: string;
 
   @property({
     type: 'string',

--- a/app/waf/test/acceptance/adc.controller.acceptance.ts
+++ b/app/waf/test/acceptance/adc.controller.acceptance.ts
@@ -176,7 +176,7 @@ describe('AdcController test', () => {
 
   it('post ' + prefix + '/adcs: create ADC HW', async function() {
     await givenAdcData(wafapp, {
-      trustedDeviceId: 'abcdefg',
+      management: {trustedDeviceId: 'abcdefg'},
     });
 
     const adc = createAdcObject({
@@ -259,13 +259,14 @@ describe('AdcController test', () => {
       .expect(200);
 
     expect(response.body.adc.status).to.equal('INSTALLED');
-    expect(response.body.adc.trustedDeviceId).to.equal(id);
+    expect(response.body.adc.management.trustedDeviceId).to.equal(id);
   });
 
   it(
     'post ' + prefix + '/adcs: create ADC HW without management info',
     async () => {
       const adc = createAdcObject({type: 'HW'});
+      // @ts-ignore adc have management property.
       delete adc.management.connection;
 
       await client
@@ -380,7 +381,7 @@ describe('AdcController test', () => {
       expect(response.body.adc.status).to.equal(AdcState.TRUSTERR);
     },
   );
-*/
+  */
 
   /* TODO: Add it back after checkAndWait supports error terminating
   it(
@@ -426,7 +427,7 @@ describe('AdcController test', () => {
       expect(response.body.adc.status).to.equal(AdcState.TRUSTERR);
     },
   );
-*/
+  */
 
   it('post ' + prefix + '/adcs: create ADC HW with trust timeout', async () => {
     ASGShouldResponseWith({
@@ -434,7 +435,7 @@ describe('AdcController test', () => {
         StubResponses.trustDeviceStatusPending200,
     });
     await givenAdcData(wafapp, {
-      trustedDeviceId: 'abcdefg',
+      management: {trustedDeviceId: 'abcdefg'},
     });
 
     const adc = createAdcObject({
@@ -497,7 +498,7 @@ describe('AdcController test', () => {
     'post ' + prefix + '/adcs: create ADC HW whose AS3 exists',
     async function() {
       await givenAdcData(wafapp, {
-        trustedDeviceId: 'abcdefg',
+        management: {trustedDeviceId: 'abcdefg'},
       });
 
       const adc = createAdcObject({
@@ -568,7 +569,7 @@ describe('AdcController test', () => {
     'post ' + prefix + '/adcs: create ADC HW with wrong AS3 extension response',
     async function() {
       await givenAdcData(wafapp, {
-        trustedDeviceId: 'abcdefg',
+        management: {trustedDeviceId: 'abcdefg'},
       });
 
       const adc = createAdcObject({
@@ -655,7 +656,7 @@ describe('AdcController test', () => {
     'post ' + prefix + '/adcs: create ADC HW with query extension exception',
     async function() {
       await givenAdcData(wafapp, {
-        trustedDeviceId: 'abcdefg',
+        management: {trustedDeviceId: 'abcdefg'},
       });
 
       const adc = createAdcObject({
@@ -735,7 +736,7 @@ describe('AdcController test', () => {
     'post ' + prefix + '/adcs: create ADC HW with install extension exception',
     async function() {
       await givenAdcData(wafapp, {
-        trustedDeviceId: 'abcdefg',
+        management: {trustedDeviceId: 'abcdefg'},
       });
 
       const adc = createAdcObject({
@@ -910,7 +911,7 @@ describe('AdcController test', () => {
   it('delete ' + prefix + '/adcs/{id}: trusted device', async () => {
     let id = uuid();
     const adc = await givenAdcData(wafapp, {
-      trustedDeviceId: id,
+      management: {trustedDeviceId: id},
     });
 
     untrustStub.returns({
@@ -931,7 +932,7 @@ describe('AdcController test', () => {
   it('delete ' + prefix + '/adcs/{id}: untrust exception', async () => {
     let id = uuid();
     const adc = await givenAdcData(wafapp, {
-      trustedDeviceId: id,
+      management: {trustedDeviceId: id},
     });
 
     untrustStub.throws('Not working');
@@ -946,7 +947,7 @@ describe('AdcController test', () => {
   it('delete ' + prefix + '/adcs/{id}: empty untrust response', async () => {
     let id = uuid();
     const adc = await givenAdcData(wafapp, {
-      trustedDeviceId: id,
+      management: {trustedDeviceId: id},
     });
 
     untrustStub.returns({
@@ -963,7 +964,7 @@ describe('AdcController test', () => {
   it('delete ' + prefix + '/adcs/{id}: wrong untrust state', async () => {
     let id = uuid();
     const adc = await givenAdcData(wafapp, {
-      trustedDeviceId: id,
+      management: {trustedDeviceId: id},
     });
 
     untrustStub.returns({

--- a/app/waf/test/acceptance/wafpolicy.controller.acceptance.ts
+++ b/app/waf/test/acceptance/wafpolicy.controller.acceptance.ts
@@ -122,7 +122,9 @@ describe('WafpolicyController', () => {
       });
 
       const adc = await givenAdcData(wafapp, {
-        trustedDeviceId: uuid(),
+        management: {
+          trustedDeviceId: uuid(),
+        },
       });
 
       uploadWafpolicyStub.returns({
@@ -154,7 +156,9 @@ describe('WafpolicyController', () => {
       });
 
       const adc = await givenAdcData(wafapp, {
-        trustedDeviceId: uuid(),
+        management: {
+          trustedDeviceId: uuid(),
+        },
       });
 
       uploadWafpolicyStub.returns({
@@ -215,7 +219,9 @@ describe('WafpolicyController', () => {
       });
 
       const adc = await givenAdcData(wafapp, {
-        trustedDeviceId: uuid(),
+        management: {
+          trustedDeviceId: uuid(),
+        },
       });
 
       checkWafpolicyStub.returns([

--- a/app/waf/test/helpers/database.helpers.ts
+++ b/app/waf/test/helpers/database.helpers.ts
@@ -34,7 +34,6 @@ import {
 } from '../../src/repositories';
 
 import {
-  Adc,
   Application,
   Declaration,
   Wafpolicy,
@@ -56,6 +55,7 @@ import {WafApplication} from '../../src';
 import {isNullOrUndefined} from 'util';
 import {ExpectedData} from '../fixtures/controllers/mocks/mock.openstack.controller';
 import {BigipBuiltInProperties} from '../../src/services';
+import {merge} from '../../src/utils';
 
 export async function givenEmptyDatabase(wafapp: WafApplication) {
   const wafpolicyrepo = await wafapp.getRepository(WafpolicyRepository);
@@ -226,8 +226,8 @@ export async function givenApplicationData(
   return await apprepo.create(obj);
 }
 
-export function createAdcObject(data?: Partial<Adc>) {
-  return Object.assign(
+export function createAdcObject(data?: object) {
+  let obj = merge(
     {
       name: 'adc target',
       description: 'my adc description',
@@ -237,24 +237,20 @@ export function createAdcObject(data?: Partial<Adc>) {
           type: 'mgmt',
           networkId: ExpectedData.bigipMgmt.networkId,
           fixedIp: ExpectedData.bigipMgmt.ipAddr,
-          macAddr: ExpectedData.bigipMgmt.macAddr,
         },
         failover1: {
           type: 'ha',
           networkId: 'd7e8635f-2d3a-42aa-a40e-8fbb177464bf',
-          macAddr: 'fa:16:3e:35:da:15',
           fixedIp: '192.168.3.3',
         },
         internal1: {
           type: 'int',
           networkId: '6acb25ec-dc68-4e07-ba45-e1a11567f9ca',
-          macAddr: 'fa:16:3e:f3:1a:b2',
           fixedIp: '192.168.4.3',
         },
         external2: {
           type: 'ext',
           networkId: '1c19251d-7e97-411a-8816-6f7a72403707',
-          macAddr: 'fa:16:3e:fd:0f:ce',
           fixedIp: '192.168.5.3',
         },
       },
@@ -294,6 +290,7 @@ export function createAdcObject(data?: Partial<Adc>) {
     },
     data,
   );
+  return obj;
 }
 
 export async function givenDeclarationData(
@@ -345,10 +342,7 @@ export function createDeclarationObject(data?: Partial<Declaration>) {
   );
 }
 
-export async function givenAdcData(
-  wafapp: WafApplication,
-  data?: Partial<Adc>,
-) {
+export async function givenAdcData(wafapp: WafApplication, data?: object) {
   const adcpepo = await wafapp.getRepository(AdcRepository);
   const obj = createAdcObject(data);
   return await adcpepo.create(obj);


### PR DESCRIPTION
In the previous PR, @haoshen61 moved related variables (vmId connection networks) to adc.management. 
This PR moves another one: trustedDeviceId. Since then, all generated values(runtime information) have been organized within adc.management. 
FYI.